### PR TITLE
Add tests for upload processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+dist-test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",

--- a/test/fileProcessor.test.mjs
+++ b/test/fileProcessor.test.mjs
@@ -1,0 +1,43 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const outputDir = path.join('dist-test','utils');
+const outputFile = path.join(outputDir,'fileProcessor.js');
+if (!existsSync(outputFile)) {
+  execFileSync('npx', [
+    'tsc', 'src/utils/fileProcessor.ts',
+    '--target','ES2022',
+    '--module','ES2022',
+    '--lib','ES2022,DOM',
+    '--outDir','dist-test',
+    '--skipLibCheck','true',
+    '--esModuleInterop',
+    '--moduleResolution','node'
+  ], { stdio: 'inherit' });
+}
+
+const { processUploadedFiles, getFilesForCommit } = await import('../dist-test/utils/fileProcessor.js');
+
+test('processUploadedFiles handles single file', async () => {
+  const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
+  const result = await processUploadedFiles([file]);
+  assert.equal(result.length, 1);
+  const entry = result[0];
+  assert.equal(entry.path, 'hello.txt');
+  assert.equal(entry.type, 'file');
+  assert.equal(entry.content, 'hello');
+});
+
+test('getFilesForCommit filters by ignore patterns', () => {
+  const tree = [
+    { path: 'file1.txt', type: 'file' },
+    { path: 'node_modules', type: 'directory', children: [
+      { path: 'module.js', type: 'file' }
+    ] }
+  ];
+  const files = getFilesForCommit(tree, ['node_modules/*']);
+  assert.deepEqual(files, ['file1.txt']);
+});


### PR DESCRIPTION
## Summary
- add minimal Node test setup for `processUploadedFiles` and `getFilesForCommit`
- ignore build artifacts
- expose `npm test` script

## Testing
- `npm test --silent`